### PR TITLE
Rename some Station type properties and add new properties

### DIFF
--- a/src/domain/ingangs-datum.ts
+++ b/src/domain/ingangs-datum.ts
@@ -1,0 +1,5 @@
+export interface IngangsDatum {
+	year?: number;
+	month?: number;
+	day?: number;
+}

--- a/src/domain/sporen.ts
+++ b/src/domain/sporen.ts
@@ -1,0 +1,3 @@
+export interface Sporen {
+	spoorNummer?: string;
+}

--- a/src/domain/station.ts
+++ b/src/domain/station.ts
@@ -1,9 +1,11 @@
 import { Namen } from './namen';
 import { StationType } from './enums';
+import { IngangsDatum } from './ingangs-datum';
+import { Sporen } from './sporen';
 
 export interface Station {
 	code?: string;
-	evacode?: string;
+	EVACode?: string;
 	heeftFaciliteiten?: boolean;
 	heeftReisassistentie?: boolean;
 	heeftVertrektijden?: boolean;
@@ -15,5 +17,7 @@ export interface Station {
 	radius?: number;
 	stationType?: StationType;
 	synoniemen?: string[];
-	uiccode?: string;
+	UICCode?: string;
+	ingangsDatum?: IngangsDatum;
+	sporen?: Sporen[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import {
 	MessageType,
 } from './domain/enums';
 import { Geldigheid } from './domain/geldigheid';
+import { IngangsDatum } from './domain/ingangs-datum';
 import { JourneyDetailLink } from './domain/journey-detail-link';
 import { LatLng } from './domain/lat-lng';
 import { Leg } from './domain/leg';
@@ -46,6 +47,7 @@ import { Self } from './domain/self';
 import { ShareURL } from './domain/share-url';
 import { Step } from './domain/step';
 import { Stop } from './domain/stop';
+import { Sporen } from './domain/sporen';
 import { Traject } from './domain/traject';
 import { TravelAdvice } from './domain/travel-advice';
 import { Trip } from './domain/trip';
@@ -86,6 +88,7 @@ export {
 	JourneyStatus,
 	MessageType,
 	Geldigheid,
+	IngangsDatum,
 	JourneyDetailLink,
 	LatLng,
 	Leg,
@@ -102,6 +105,7 @@ export {
 	ShareURL,
 	Step,
 	Stop,
+	Sporen,
 	Traject,
 	TravelAdvice,
 	Trip,


### PR DESCRIPTION
Some of the Station type properties no longer match what's returned by the NS API. 
This small PR is for updating and adding some properties to the Station type. 

Updated properties: `UICCode`, `EVACode`
New properties: `sporen`, `ingangsDatum`

**Screenshots of NS API `GET` `/stations` response:**
![image](https://user-images.githubusercontent.com/9452132/70710641-8699e380-1cd7-11ea-925d-721d2424b4c1.png)

![image](https://user-images.githubusercontent.com/9452132/70710499-36228600-1cd7-11ea-9875-5507e9d4eef6.png)
